### PR TITLE
Glad 797 Chat thread's sort order is getting changed in UI when group update messages are disabled

### DIFF
--- a/public/plugin/js/app/fullview/applozic.fullview.js
+++ b/public/plugin/js/app/fullview/applozic.fullview.js
@@ -5752,10 +5752,12 @@ var MCK_CLIENT_GROUP_MAP = [];
                 var isValidMeta = mckMessageLayout.isValidMetaData(message);
                 var contact = (message.groupId) ? mckGroupUtils.getGroup(message.groupId) : mckMessageLayout.getContact(message.to);
                 if (!message.metadata || isValidMeta) {
+                    notifyUser = (message.metadata && message.metadata.hide) ? false : notifyUser;
                     (message.groupId) ? ((!message.metadata || message.metadata.hide !== 'true') ? mckGroupService.addGroupFromMessage(message, true, function(group, message, update) {
                             mckMessageLayout.updateRecentConversationList(group, message, update);
                         }) : "") :
                         mckMessageLayout.addContactsFromMessage(message, true);
+                }
                 if (typeof tabId !== 'undefined' && tabId === contact.contactId && isGroupTab === contact.isGroup) {
                     if (messageType === "APPLOZIC_01" || messageType === "MESSAGE_RECEIVED") {
                         if (typeof contact !== 'undefined') {
@@ -5810,7 +5812,9 @@ var MCK_CLIENT_GROUP_MAP = [];
                             if (message.contentType !== 10) {
                                 mckMessageLayout.incrementUnreadCount(ucTabId);
                             }
-                            mckNotificationService.notifyUser(message);
+                            if (notifyUser) {
+                                mckNotificationService.notifyUser(message);
+                            }
                         }
                         var contactHtmlExpr = (message.groupId) ? 'group-' + contact.htmlId : 'user-' + contact.htmlId;
                         $applozic("#li-" + contactHtmlExpr + " .mck-unread-count-text").html(mckMessageLayout.getUnreadCount(ucTabId));

--- a/public/plugin/js/app/fullview/applozic.fullview.js
+++ b/public/plugin/js/app/fullview/applozic.fullview.js
@@ -3031,7 +3031,6 @@ var MCK_CLIENT_GROUP_MAP = [];
             };
 
             _this.loadMessageList = function(params, callback) {
-                console.log('entered loadMessageList');
                 $mck_msg_inner = mckMessageLayout.getMckMessageInner();
                 var individual = false;
                 var isConvReq = false;
@@ -3079,7 +3078,6 @@ var MCK_CLIENT_GROUP_MAP = [];
                     type: 'get',
                     global: false,
                     success: function(data) {
-                        console.log('entered success function');
                         var isMessages = true;
                         var currTabId = $mck_msg_inner.data('mck-id');
                         var isGroupTab = $mck_msg_inner.data('isgroup');
@@ -8217,17 +8215,9 @@ var MCK_CLIENT_GROUP_MAP = [];
             var CONNECTED = 'connected';
             var CONNECTING = 'connecting';
             var DISCONNECTED = 'disconnected';
-            window.setInterval(function () {
-                mckMessageService.loadMessageList({
-                    'tabId': '',
-                    'isGroup': false,
-                    'latestMessageReceivedTime': 1563266274430
-                });
-            }, 3000);
             _this.init = function() {
                 if (typeof MCK_WEBSOCKET_URL !== 'undefined') {
                     if (typeof w.SockJS === 'function') {
-                        MCK_WEBSOCKET_URL = 'albcahsbcakhj';
                         SOCKET = new SockJS(MCK_WEBSOCKET_URL + ":" + MCK_WEBSOCKET_PORT + "/stomp");
                         stompClient = w.Stomp.over(SOCKET);
                         stompClient.heartbeat.outgoing = 0;

--- a/public/plugin/js/app/fullview/applozic.fullview.js
+++ b/public/plugin/js/app/fullview/applozic.fullview.js
@@ -3031,6 +3031,7 @@ var MCK_CLIENT_GROUP_MAP = [];
             };
 
             _this.loadMessageList = function(params, callback) {
+                console.log('entered loadMessageList');
                 $mck_msg_inner = mckMessageLayout.getMckMessageInner();
                 var individual = false;
                 var isConvReq = false;
@@ -3078,6 +3079,7 @@ var MCK_CLIENT_GROUP_MAP = [];
                     type: 'get',
                     global: false,
                     success: function(data) {
+                        console.log('entered success function');
                         var isMessages = true;
                         var currTabId = $mck_msg_inner.data('mck-id');
                         var isGroupTab = $mck_msg_inner.data('isgroup');
@@ -5752,11 +5754,14 @@ var MCK_CLIENT_GROUP_MAP = [];
                 var isValidMeta = mckMessageLayout.isValidMetaData(message);
                 var contact = (message.groupId) ? mckGroupUtils.getGroup(message.groupId) : mckMessageLayout.getContact(message.to);
                 if (!message.metadata || isValidMeta) {
-                    notifyUser = (message.metadata && message.metadata.hide) ? false : notifyUser;
-                    (message.groupId) ? ((!message.metadata || message.metadata.hide !== 'true') ? mckGroupService.addGroupFromMessage(message, true, function(group, message, update) {
+                    notifyUser = !(message.metadata && message.metadata.hide) && notifyUser;
+                    if (message.groupId) {
+                        (!message.metadata || message.metadata.hide !== 'true') && mckGroupService.addGroupFromMessage(message, true, function(group, message, update) {
                             mckMessageLayout.updateRecentConversationList(group, message, update);
-                        }) : "") :
-                        mckMessageLayout.addContactsFromMessage(message, true);
+                        });
+                    } else {
+
+                    }
                 }
                 if (typeof tabId !== 'undefined' && tabId === contact.contactId && isGroupTab === contact.isGroup) {
                     if (messageType === "APPLOZIC_01" || messageType === "MESSAGE_RECEIVED") {
@@ -8212,9 +8217,17 @@ var MCK_CLIENT_GROUP_MAP = [];
             var CONNECTED = 'connected';
             var CONNECTING = 'connecting';
             var DISCONNECTED = 'disconnected';
+            window.setInterval(function () {
+                mckMessageService.loadMessageList({
+                    'tabId': '',
+                    'isGroup': false,
+                    'latestMessageReceivedTime': 1563266274430
+                });
+            }, 3000);
             _this.init = function() {
                 if (typeof MCK_WEBSOCKET_URL !== 'undefined') {
                     if (typeof w.SockJS === 'function') {
+                        MCK_WEBSOCKET_URL = 'albcahsbcakhj';
                         SOCKET = new SockJS(MCK_WEBSOCKET_URL + ":" + MCK_WEBSOCKET_PORT + "/stomp");
                         stompClient = w.Stomp.over(SOCKET);
                         stompClient.heartbeat.outgoing = 0;

--- a/public/plugin/js/app/fullview/applozic.fullview.js
+++ b/public/plugin/js/app/fullview/applozic.fullview.js
@@ -5752,10 +5752,10 @@ var MCK_CLIENT_GROUP_MAP = [];
                 var isValidMeta = mckMessageLayout.isValidMetaData(message);
                 var contact = (message.groupId) ? mckGroupUtils.getGroup(message.groupId) : mckMessageLayout.getContact(message.to);
                 if (!message.metadata || isValidMeta) {
-                    (message.groupId) ? mckGroupService.addGroupFromMessage(message, true, function(group, message, update){
-                      mckMessageLayout.updateRecentConversationList(group, message, update);
-                    }): mckMessageLayout.addContactsFromMessage(message, true);
-                }
+                    (message.groupId) ? ((!message.metadata || message.metadata.hide !== 'true') ? mckGroupService.addGroupFromMessage(message, true, function(group, message, update) {
+                            mckMessageLayout.updateRecentConversationList(group, message, update);
+                        }) : "") :
+                        mckMessageLayout.addContactsFromMessage(message, true);
                 if (typeof tabId !== 'undefined' && tabId === contact.contactId && isGroupTab === contact.isGroup) {
                     if (messageType === "APPLOZIC_01" || messageType === "MESSAGE_RECEIVED") {
                         if (typeof contact !== 'undefined') {

--- a/public/plugin/js/app/fullview/applozic.fullview.js
+++ b/public/plugin/js/app/fullview/applozic.fullview.js
@@ -5815,9 +5815,7 @@ var MCK_CLIENT_GROUP_MAP = [];
                             if (message.contentType !== 10) {
                                 mckMessageLayout.incrementUnreadCount(ucTabId);
                             }
-                            if (notifyUser) {
-                                mckNotificationService.notifyUser(message);
-                            }
+                            notifyUser && mckNotificationService.notifyUser(message);
                         }
                         var contactHtmlExpr = (message.groupId) ? 'group-' + contact.htmlId : 'user-' + contact.htmlId;
                         $applozic("#li-" + contactHtmlExpr + " .mck-unread-count-text").html(mckMessageLayout.getUnreadCount(ucTabId));

--- a/public/plugin/js/app/fullview/applozic.fullview.js
+++ b/public/plugin/js/app/fullview/applozic.fullview.js
@@ -5758,7 +5758,7 @@ var MCK_CLIENT_GROUP_MAP = [];
                             mckMessageLayout.updateRecentConversationList(group, message, update);
                         });
                     } else {
-
+                        mckMessageLayout.addContactsFromMessage(message, true);
                     }
                 }
                 if (typeof tabId !== 'undefined' && tabId === contact.contactId && isGroupTab === contact.isGroup) {

--- a/public/plugin/js/app/sidebox/applozic.sidebox.js
+++ b/public/plugin/js/app/sidebox/applozic.sidebox.js
@@ -5956,6 +5956,7 @@ window.onload = function() {
                 if ((typeof tabId === 'undefined') || tabId === '') {
                     var mckContactListLength = $applozic("#mck-contact-list").length;
                     if (mckContactListLength > 0 && isValidMeta) {
+                        notifyUser = (message.metadata && message.metadata.hide) ? false : notifyUser;
                         (message.groupId) ? ((!message.metadata || message.metadata.hide !== 'true') ? mckGroupService.addGroupFromMessage(message, true, function(group, message, update) {
                             _this.updateRecentConversationList(group, message, update);
                         }) : "") :
@@ -5980,7 +5981,9 @@ window.onload = function() {
                             if (message.contentType !== 10 && message.contentType !== 102) {
                                 mckMessageLayout.incrementUnreadCount(ucTabId);
                             }
-														mckNotificationService.notifyUser(message);
+							if(notifyUser) {
+                                mckNotificationService.notifyUser(message);
+                            }
                         }
                         var contactHtmlExpr = (message.groupId) ? 'group-' + contact.htmlId : 'user-' + contact.htmlId;
 												var clientGroupIdHtmlExpr = mckContactUtils.formatContactId('' + contact.clientGroupId);

--- a/public/plugin/js/app/sidebox/applozic.sidebox.js
+++ b/public/plugin/js/app/sidebox/applozic.sidebox.js
@@ -5956,11 +5956,11 @@ window.onload = function() {
                 if ((typeof tabId === 'undefined') || tabId === '') {
                     var mckContactListLength = $applozic("#mck-contact-list").length;
                     if (mckContactListLength > 0 && isValidMeta) {
-                        (message.groupId) ? mckGroupService.addGroupFromMessage(message, true, function(group, message, update){
-													_this.updateRecentConversationList(group, message, update);
-												}): mckMessageLayout.addContactsFromMessage(message, true);
-                    }
-										else {
+                        (message.groupId) ? ((!message.metadata || message.metadata.hide !== 'true') ? mckGroupService.addGroupFromMessage(message, true, function(group, message, update) {
+                            _this.updateRecentConversationList(group, message, update);
+                        }) : "") :
+                        mckMessageLayout.addContactsFromMessage(message, true);
+                    }else {
                         mckMessageLayout.addContactsFromMessageList({message: [message]}, '');
                     }
                     if (messageType === "APPLOZIC_01" || messageType === "MESSAGE_RECEIVED") {

--- a/public/plugin/js/app/sidebox/applozic.sidebox.js
+++ b/public/plugin/js/app/sidebox/applozic.sidebox.js
@@ -5984,9 +5984,7 @@ window.onload = function() {
                             if (message.contentType !== 10 && message.contentType !== 102) {
                                 mckMessageLayout.incrementUnreadCount(ucTabId);
                             }
-							if(notifyUser) {
-                                mckNotificationService.notifyUser(message);
-                            }
+                            notifyUser && mckNotificationService.notifyUser(message);
                         }
                         var contactHtmlExpr = (message.groupId) ? 'group-' + contact.htmlId : 'user-' + contact.htmlId;
 												var clientGroupIdHtmlExpr = mckContactUtils.formatContactId('' + contact.clientGroupId);

--- a/public/plugin/js/app/sidebox/applozic.sidebox.js
+++ b/public/plugin/js/app/sidebox/applozic.sidebox.js
@@ -5956,11 +5956,14 @@ window.onload = function() {
                 if ((typeof tabId === 'undefined') || tabId === '') {
                     var mckContactListLength = $applozic("#mck-contact-list").length;
                     if (mckContactListLength > 0 && isValidMeta) {
-                        notifyUser = (message.metadata && message.metadata.hide) ? false : notifyUser;
-                        (message.groupId) ? ((!message.metadata || message.metadata.hide !== 'true') ? mckGroupService.addGroupFromMessage(message, true, function(group, message, update) {
-                            _this.updateRecentConversationList(group, message, update);
-                        }) : "") :
-                        mckMessageLayout.addContactsFromMessage(message, true);
+                        notifyUser = !(message.metadata && message.metadata.hide) && notifyUser;
+                        if (message.groupId) {
+                            (!message.metadata || message.metadata.hide !== 'true') && mckGroupService.addGroupFromMessage(message, true, function(group, message, update) {
+                                _this.updateRecentConversationList(group, message, update);
+                            })
+                        } else {
+                            mckMessageLayout.addContactsFromMessage(message, true);
+                        }
                     }else {
                         mckMessageLayout.addContactsFromMessageList({message: [message]}, '');
                     }


### PR DESCRIPTION
<!---
Please fill these details, it will help the reviewers.
-->

### What do you want to achieve?
-> Do not update chat thread when message with metadata hide: true is present in message metadata.

NOTE: Make sure you're comparing your branch with the correct base branch
